### PR TITLE
Request body content type agnostic

### DIFF
--- a/app/com/nappin/play/recaptcha/RecaptchaVerifier.scala
+++ b/app/com/nappin/play/recaptcha/RecaptchaVerifier.scala
@@ -52,6 +52,34 @@ class RecaptchaVerifier @Inject() (settings: RecaptchaSettings, parser: Response
 
     val logger = Logger(this.getClass)
 
+    private def getRequestPostData()(implicit request: play.api.mvc.Request[_]): Map[String, Seq[String]] = {
+        import play.api.libs.json._
+
+        def fromJson(prefix: String = "", js: JsValue): Map[String, String] = js match {
+            case JsObject(fields) => {
+                fields.map { case (key, value) => fromJson(Option(prefix).filterNot(_.isEmpty).map(_ + ".").getOrElse("") + key, value) }.foldLeft(Map.empty[String, String])(_ ++ _)
+            }
+            case JsArray(values) => {
+                values.zipWithIndex.map { case (value, i) => fromJson(prefix + "[" + i + "]", value) }.foldLeft(Map.empty[String, String])(_ ++ _)
+            }
+            case JsNull => Map.empty
+            case JsUndefined() => Map.empty
+            case JsBoolean(value) => Map(prefix -> value.toString)
+            case JsNumber(value) => Map(prefix -> value.toString)
+            case JsString(value) => Map(prefix -> value.toString)
+        }
+
+        request.body match {
+            case body: play.api.mvc.AnyContent if body.asFormUrlEncoded.isDefined => body.asFormUrlEncoded.get
+            case body: play.api.mvc.AnyContent if body.asMultipartFormData.isDefined => body.asMultipartFormData.get.asFormUrlEncoded
+            case body: play.api.mvc.AnyContent if body.asJson.isDefined => fromJson(js = body.asJson.get).mapValues(Seq(_))
+            case body: Map[_, _] => body.asInstanceOf[Map[String, Seq[String]]]
+            case body: play.api.mvc.MultipartFormData[_] => body.asFormUrlEncoded
+            case body: play.api.libs.json.JsValue => fromJson(js = body).mapValues(Seq(_))
+            case _ => Map.empty[String, Seq[String]]
+        }
+    }
+
     /**
      * High level API (using Play forms).
      *
@@ -80,7 +108,7 @@ class RecaptchaVerifier @Inject() (settings: RecaptchaSettings, parser: Response
 
         val boundForm = form.bindFromRequest
 
-        val response =  readResponse(request.body.asFormUrlEncoded.get)
+        val response = readResponse(getRequestPostData())
 
         if (response.length < 1) {
             // probably an end user error


### PR DESCRIPTION
Allows to handle all types of body content types the form can handle as well.

This code is simply copy pasted from the play framework source code for `Form`. Unfortunately the methods are not exposed.

See: #4 