### PR TITLE
Support Playframework 2.8.8+

### DIFF
--- a/app/com/nappin/play/recaptcha/RecaptchaModule.scala
+++ b/app/com/nappin/play/recaptcha/RecaptchaModule.scala
@@ -26,10 +26,10 @@ import play.api.{Environment, Configuration}
 class RecaptchaModule extends Module {
   def bindings(environment: Environment, configuration: Configuration) = {
     Seq(
-      bind[RecaptchaSettings].toSelf.eagerly,
-      bind[ResponseParser].toSelf.eagerly,
-      bind[RecaptchaVerifier].toSelf.eagerly,
-      bind[WidgetHelper].toSelf.eagerly
+      bind[RecaptchaSettings].toSelf.eagerly(),
+      bind[ResponseParser].toSelf.eagerly(),
+      bind[RecaptchaVerifier].toSelf.eagerly(),
+      bind[WidgetHelper].toSelf.eagerly()
     )
   }
 }

--- a/app/com/nappin/play/recaptcha/RecaptchaVerifier.scala
+++ b/app/com/nappin/play/recaptcha/RecaptchaVerifier.scala
@@ -146,7 +146,7 @@ class RecaptchaVerifier @Inject() (settings: RecaptchaSettings, parser: Response
     def bindFromRequestAndVerify[T](form: Form[T])(implicit request: Request[AnyContent],
             context: ExecutionContext): Future[Form[T]] = {
 
-        val boundForm = form.bindFromRequest
+        val boundForm = form.bindFromRequest()
 
         val response = readResponse(getRequestPostData())
 

--- a/app/com/nappin/play/recaptcha/RecaptchaVerifier.scala
+++ b/app/com/nappin/play/recaptcha/RecaptchaVerifier.scala
@@ -19,12 +19,12 @@ import javax.inject.{Inject, Singleton}
 import play.api.Logger
 import play.api.mvc.{AnyContent, Request}
 import play.api.data.Form
+import play.api.data.FormBinding.Implicits.formBinding
 import play.api.libs.ws.WSClient
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration.Duration
 import java.util.concurrent.TimeUnit
-
 import play.api.libs.json._
 
 object RecaptchaVerifier {
@@ -106,7 +106,7 @@ class RecaptchaVerifier @Inject() (settings: RecaptchaSettings, parser: Response
                     fromJson(recursiveKey, value)
                 }
             }
-            return f.foldLeft(Map.empty[String, Seq[String]])(_ ++ _)
+            f.foldLeft(Map.empty[String, Seq[String]])(_ ++ _)
         }
         case JsArray(values) => {
             values.zipWithIndex.map {

--- a/app/com/nappin/play/recaptcha/WidgetHelper.scala
+++ b/app/com/nappin/play/recaptcha/WidgetHelper.scala
@@ -167,7 +167,7 @@ class WidgetHelper @Inject()(settings: RecaptchaSettings) {
     * @return The formatted CSS class attribute
     */
   def formatOtherAttributes(args: (Symbol, String)*): String = {
-    args.filter((t) => t._1 != Symbol("class")).map((t) => t._1.toString().substring(1) + "=\"" + t._2 + "\"").mkString(" ")
+    args.filter((t) => t._1 != Symbol("class")).map((t) => t._1.name + "=\"" + t._2 + "\"").mkString(" ")
   }
 
   /**

--- a/build.sbt
+++ b/build.sbt
@@ -6,8 +6,8 @@ version := "2.4"
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
 // default Scala binary compatibility
-scalaVersion := "2.13.0"
-crossScalaVersions := Seq("2.12.8", "2.13.0")
+scalaVersion := "2.13.6"
+crossScalaVersions := Seq("2.12.8", "2.13.6")
 
 libraryDependencies ++= Seq(
   ws,
@@ -24,7 +24,7 @@ pgpSecretRing := file("/home/chris/Development/SonatypeKey/secring.asc")
 pgpPublicRing := file("/home/chris/Development/SonatypeKey/pubring.asc")
 
 // adds "test-conf" to the test classpath (for message resolving)
-unmanagedClasspath in Test += baseDirectory.value / "test-conf"
+Test / unmanagedClasspath += baseDirectory.value / "test-conf"
 
 // needed to publish to maven central
 publishMavenStyle := true
@@ -37,7 +37,7 @@ publishTo := {
     Some("releases"  at nexus + "service/local/staging/deploy/maven2")
 }
 
-publishArtifact in Test := false
+Test / publishArtifact := false
 pomIncludeRepository := { _ => false }
 
 pomExtra := (

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.5.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 //resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.3")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.8")
 
 // The PGP plugin (for signing sonatype releases)
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")


### PR DESCRIPTION
This changes supports Playframework 2.8.8. It seems the way of request handling for forms have changed in 2.8.7 and also symbol handling. These changes seem to fix the issue of not resolving the correct method