### PR TITLE
Support Playframework 3.0.x

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,9 @@ version := "2.5"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
-crossScalaVersions := Seq("2.12.8", "2.13.6")
+scalaVersion := "2.13.12"
+// TODO: cross build for 3.3.1
+crossScalaVersions := Seq("2.13.12")
 
 libraryDependencies ++= Seq(
   ws,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.2
+sbt.version=1.9.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,11 +1,11 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.8")
+addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.1")
 
 // The PGP plugin (for signing sonatype releases)
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")
 
 // The scoverage plugin (measures statement coverage for unit tests)
-addSbtPlugin("org.scoverage" %% "sbt-scoverage" % "1.8.2")
+addSbtPlugin("org.scoverage" %% "sbt-scoverage" % "2.0.9")
 
 // Shows an ascii library dependency graph (run dependencyTree)
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2")


### PR DESCRIPTION
This changes support Playframework 3.0.x.
Play 3.0.x supports Scala 2.13 and 3.x, but not 2.12.

If you want to build for Scala 3.x, some codes need to be changed.
